### PR TITLE
Fix silent NameError in entity relation lookup, and add the missing tests + CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Grouped, weekly dependency updates. requirements.txt is unpinned today, so
+# these PRs mainly track the docker base image and the workflow actions until
+# the Python dependencies are pinned.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+# Runs on pull requests, which build-deploy.yml does not: that workflow only
+# fires on push to main, so until now nothing checked a change before it was
+# merged and deployed.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v \
+            --cov=services --cov-report=term-missing --cov-report=xml
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: coverage.xml
+          if-no-files-found: warn
+
+  # requirements.txt is unpinned, so a fresh resolve can start failing without
+  # anything in this repository changing. Building the image is what catches
+  # that — and it also proves the app still imports.
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build the image
+        run: docker build --tag kgqagent-text2sparql:ci .

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+"""Present so pytest puts the repository root on sys.path.
+
+Without it, `from services import ld_utils` only resolves when pytest happens
+to be invoked from the repository root.
+"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# Dependencies needed to run the unit tests. The tests cover the pure logic in
+# services/ld_utils.py, so the heavy ML stack from requirements.txt (torch,
+# sentence-transformers, faiss) is deliberately not needed here — that keeps
+# the PR gate fast. requirements.txt itself is exercised by the docker job.
+pytest>=8.0
+pytest-cov>=5.0
+requests
+fuzzywuzzy
+SPARQLWrapper
+rdflib

--- a/services/ld_utils.py
+++ b/services/ld_utils.py
@@ -1,8 +1,11 @@
 import json
+import logging
 import requests
 from fuzzywuzzy import fuzz
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib.plugins.sparql.parser import parseQuery
+
+logger = logging.getLogger(__name__)
 
 
 prefixes_list = [
@@ -41,8 +44,10 @@ def search_entity(query: str, lang: str = "en", similarity: int = 90, search_lim
             else:
               ne_list.append({wdt_label: f"http://www.wikidata.org/entity/{wdt_id}"})
     return ne_list, rel_list
-  except Exception as e:
-    print(str(e))
+  except Exception:
+    # Logged with a traceback: swallowing this silently is what hid a
+    # NameError in get_relations for a long time.
+    logger.exception("entity search failed for query %r", query)
     return [], []
 
 def falcon_rel(query: str):
@@ -58,8 +63,8 @@ def falcon_rel(query: str):
     for entity in data["entities_wikidata"]:
        ent_list.append({entity["label"]: entity["URI"]})
     return rel_list, ent_list
-  except Exception as e:
-    print(str(e))
+  except Exception:
+    logger.exception("Falcon relation lookup failed for query %r", query)
     return [], []
   
 def extract_code_blocks(text):
@@ -103,8 +108,8 @@ def execute(query: str, endpoint_url: str = 'http://141.57.8.18:40201/dbpedia/sp
         response = sparql.query().convert()
         return response
     except Exception as e:
+        logger.exception("SPARQL execution failed against %s", endpoint_url)
         e = str(e)
-        print(e)
         if 'MalformedQueryException' in e or 'bad formed' in e:
             return {'error': str(e)}
         return  {'error': str(e)}
@@ -116,8 +121,12 @@ def get_relations(uri):
   }}
   """
 
-  results = transform_sparql_json_to_dataframe(execute(sparql))
-  if results.shape[0] > 0:
-    return [res.split("/")[-1] for res in results.uri]
-  else:
-    return []
+  # Read the SPARQL JSON result directly. `execute` returns either the parsed
+  # response or {'error': ...}, so a failed query yields no bindings here.
+  response = execute(sparql)
+  bindings = (response or {}).get("results", {}).get("bindings", [])
+  return [
+    binding["uri"]["value"].split("/")[-1]
+    for binding in bindings
+    if binding.get("uri", {}).get("value")
+  ]

--- a/tests/test_ld_utils.py
+++ b/tests/test_ld_utils.py
@@ -1,0 +1,164 @@
+"""Tests for the linked-data helpers.
+
+These cover the pure logic only, so they need neither an OpenAI key nor a
+reachable SPARQL endpoint; every network call is stubbed.
+"""
+import pytest
+
+from services import ld_utils
+
+
+# --------------------------------------------------------------------------
+# extract_code_blocks
+# --------------------------------------------------------------------------
+
+def test_extract_code_blocks_prefers_sparql_fences():
+    text = (
+        "Here you go:\n"
+        "```sparql\nSELECT * WHERE { ?s ?p ?o }\n```\n"
+        "```python\nprint('not this one')\n```\n"
+    )
+    blocks = ld_utils.extract_code_blocks(text)
+
+    assert len(blocks) == 1
+    assert "SELECT * WHERE" in blocks[0]
+    assert "print(" not in blocks[0]
+
+
+def test_extract_code_blocks_falls_back_to_untagged_fences():
+    text = "```\nSELECT * WHERE { ?s ?p ?o }\n```"
+    blocks = ld_utils.extract_code_blocks(text)
+
+    assert len(blocks) == 1
+    assert "SELECT" in blocks[0]
+
+
+def test_extract_code_blocks_returns_empty_without_fences():
+    assert ld_utils.extract_code_blocks("no code here") == []
+
+
+# --------------------------------------------------------------------------
+# post_process
+# --------------------------------------------------------------------------
+
+def test_post_process_prepends_missing_prefixes():
+    query = ld_utils.post_process("```sparql\nSELECT ?s WHERE { ?s dbo:abstract ?o }\n```")
+
+    assert "PREFIX dbo: <http://dbpedia.org/ontology/>" in query
+    assert query.rstrip().endswith("SELECT ?s WHERE { ?s dbo:abstract ?o }")
+
+
+def test_post_process_does_not_duplicate_declared_prefixes():
+    declared = "PREFIX dbo: <http://dbpedia.org/ontology/>"
+    query = ld_utils.post_process(f"{declared}\nSELECT ?s WHERE {{ ?s dbo:abstract ?o }}")
+
+    assert query.count(declared) == 1
+
+
+def test_post_process_handles_bare_queries_without_fences():
+    query = ld_utils.post_process("SELECT ?s WHERE { ?s ?p ?o }")
+
+    assert "SELECT ?s WHERE" in query
+
+
+# --------------------------------------------------------------------------
+# get_relations
+#
+# Regression guard: this used to call an undefined
+# transform_sparql_json_to_dataframe, so it raised NameError on every call.
+# --------------------------------------------------------------------------
+
+def _binding(uri):
+    return {"uri": {"type": "uri", "value": uri}}
+
+
+def test_get_relations_extracts_property_ids(monkeypatch):
+    monkeypatch.setattr(ld_utils, "execute", lambda _q: {
+        "results": {"bindings": [
+            _binding("http://www.wikidata.org/prop/direct/P31"),
+            _binding("http://www.wikidata.org/prop/direct/P279"),
+        ]}
+    })
+
+    assert ld_utils.get_relations("Q42") == ["P31", "P279"]
+
+
+def test_get_relations_returns_empty_for_no_bindings(monkeypatch):
+    monkeypatch.setattr(ld_utils, "execute", lambda _q: {"results": {"bindings": []}})
+
+    assert ld_utils.get_relations("Q42") == []
+
+
+def test_get_relations_returns_empty_when_the_endpoint_errors(monkeypatch):
+    # `execute` reports failures as {'error': ...} rather than raising.
+    monkeypatch.setattr(ld_utils, "execute", lambda _q: {"error": "boom"})
+
+    assert ld_utils.get_relations("Q42") == []
+
+
+def test_get_relations_does_not_raise_name_error(monkeypatch):
+    """The original defect: any call blew up with NameError."""
+    monkeypatch.setattr(ld_utils, "execute", lambda _q: {"results": {"bindings": []}})
+
+    try:
+        ld_utils.get_relations("Q42")
+    except NameError as exc:  # pragma: no cover - fails the test deliberately
+        pytest.fail(f"get_relations raised NameError: {exc}")
+
+
+# --------------------------------------------------------------------------
+# search_entity
+# --------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_search_entity_reports_relations_when_the_entity_has_them(monkeypatch):
+    monkeypatch.setattr(ld_utils.requests, "get", lambda *a, **k: _FakeResponse(
+        {"search": [{"label": "Douglas Adams", "id": "Q42"}]}
+    ))
+    monkeypatch.setattr(ld_utils.fuzz, "partial_ratio", lambda a, b: 100)
+    monkeypatch.setattr(ld_utils, "get_relations", lambda _uri: ["P31"])
+
+    entities, relations = ld_utils.search_entity("Douglas Adams")
+
+    # Previously this returned ([], []) because get_relations raised NameError
+    # and the bare except swallowed it.
+    assert relations == [{"Douglas Adams": "http://www.wikidata.org/prop/direct/P31"}]
+    assert entities == []
+
+
+def test_search_entity_reports_the_entity_when_it_has_no_relations(monkeypatch):
+    monkeypatch.setattr(ld_utils.requests, "get", lambda *a, **k: _FakeResponse(
+        {"search": [{"label": "Douglas Adams", "id": "Q42"}]}
+    ))
+    monkeypatch.setattr(ld_utils.fuzz, "partial_ratio", lambda a, b: 100)
+    monkeypatch.setattr(ld_utils, "get_relations", lambda _uri: [])
+
+    entities, relations = ld_utils.search_entity("Douglas Adams")
+
+    assert entities == [{"Douglas Adams": "http://www.wikidata.org/entity/Q42"}]
+    assert relations == []
+
+
+def test_search_entity_skips_labels_below_the_similarity_threshold(monkeypatch):
+    monkeypatch.setattr(ld_utils.requests, "get", lambda *a, **k: _FakeResponse(
+        {"search": [{"label": "Something Else", "id": "Q1"}]}
+    ))
+    monkeypatch.setattr(ld_utils.fuzz, "partial_ratio", lambda a, b: 10)
+
+    assert ld_utils.search_entity("Douglas Adams") == ([], [])
+
+
+def test_search_entity_survives_a_network_failure(monkeypatch):
+    def boom(*a, **k):
+        raise ConnectionError("wikidata unreachable")
+
+    monkeypatch.setattr(ld_utils.requests, "get", boom)
+
+    assert ld_utils.search_entity("Douglas Adams") == ([], [])


### PR DESCRIPTION
## A silent correctness bug

`services/ld_utils.py` calls a function that does not exist:

```python
results = transform_sparql_json_to_dataframe(execute(sparql))
```

`transform_sparql_json_to_dataframe` is **not defined or imported anywhere in the repository**, so every call to `get_relations()` raised:

```
NameError: name 'transform_sparql_json_to_dataframe' is not defined
```

`get_relations()` is reached only from `search_entity()`, whose `except Exception: print(...)` swallowed the error and returned `([], [])`. So the failure was invisible: for **any** Wikidata hit that cleared the fuzzy-match threshold, the entity and relation candidates were silently dropped and the agent continued with nothing.

Reproduced before the fix:

```
get_relations raises -> NameError: name 'transform_sparql_json_to_dataframe' is not defined
search_entity returns -> [] []   <- silently empty despite a matching hit
```

### Fix

Read the SPARQL JSON result directly, which removes the need for the missing pandas helper. `execute()` reports failures as `{'error': ...}` rather than raising, so an endpoint error yields an empty list.

The two swallowing handlers now `logger.exception(...)` instead of `print(...)`, so the next bug of this kind is visible rather than silent.

## Why it went unnoticed

There were **no tests**, and `build-deploy.yml` only fires on `push` to `main` — so nothing checked a change before it was merged *and deployed*.

## What this adds

- **14 tests** for the pure logic in `ld_utils.py`: fenced-block extraction, prefix handling in `post_process`, `get_relations` (with an explicit regression guard for the `NameError`), and the `search_entity` paths.
  Reverting the `get_relations` fix turns **4 of them red** — verified, they are a real gate, not decoration.
- **CI on pull requests**: pytest + coverage, plus a docker image build. The image build matters here because `requirements.txt` is entirely unpinned, so a fresh resolve can start failing with no change to this repository.
- `requirements-dev.txt` keeps the test job fast — the tests need neither an OpenAI key nor the torch/faiss/sentence-transformers stack.
- `conftest.py` so tests import regardless of the invocation directory.
- Weekly grouped **Dependabot** for pip, docker and github-actions.

## Verification

```
14 passed
services/ld_utils.py    83 stmts    63% coverage
```

The `llm_agent_*` modules remain uncovered — exercising them needs the heavy ML stack and live API credentials. That is a sensible follow-up, not something to fake here.

## Two things I deliberately did *not* change

1. **`requirements.txt` is fully unpinned** (`langchain`, `langgraph`, `langchain-community`, … with no versions). This makes builds non-reproducible and is the same class of problem that has bitten other repositories in the org, where the langchain family must move together. Pinning it is a judgement call about the deployed service, so it should be a deliberate, separate change.
2. **There is no LICENSE.** This is a public repository with ★6 and an award listed in the README, which currently leaves it legally unusable by anyone else. Choosing a licence is the owner's call — most of the org is MIT.
